### PR TITLE
Feature/sitemapindex

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,35 @@ Then implement the route for the sitemap.xml with your custom logic:
     ->bind('sitemap');
 ```
 
+You can implement a sitemapindex with the option "start" and the following example:
+```php
+    $app->register(new TM\Provider\SitemapServiceProvider(), [
+        'sitemap.options' => [
+            'charset' => 'ISO-8859-1',
+            'version' => '1.0',
+            'scheme' => 'http://www.sitemaps.org/schemas/sitemap/0.8',
+            'start' => false
+        ]
+    ]);
+
+    ...
+
+    $app->get('sitemap.xml', function () use ($app) {
+  
+      $host = $app['request']->getSchemeAndHttpHost();
+      
+      $sitemap = $app['sitemap'];
+      $sitemap
+        ->startElement('sitemapindex')
+        ->addSitemap($host . '/firstsitemap.xml')
+        ->addSitemap($host . '/secondsitemap.xml', new \DateTime("yesterday"))
+      ;
+  
+      return $sitemap->generate();
+    })
+    ->bind('sitemap');
+```
+
 ### Contributing
 
 Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for information on how to contribute.

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -80,6 +80,27 @@ class FeatureContext implements Context, SnippetAcceptingContext
     }
 
     /**
+     * @param string $url
+     * @param string $name
+     * @param mixed  $value
+     *
+     * @When I add a sitemap :url with parameter :name and value :value
+     */
+    public function addSitemap($url, $name = null, $value = null)
+    {
+        switch ($name)
+        {
+            case 'lastmod':
+                $datetime = new \DateTime($value);
+                $this->app['sitemap']->addSitemap($url, $datetime);
+                break;
+
+            default:
+                $this->app['sitemap']->addSitemap($url);
+        }
+    }
+
+    /**
      * @param string $charset
      * @param string $version
      * @param string $scheme

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -30,6 +30,19 @@ class FeatureContext implements Context, SnippetAcceptingContext
     }
 
     /**
+     * @Given Service with charset :charset, version :version, start :start and scheme :scheme is available
+     */
+    public function isManualServiceAvailable($charset, $version, $start, $scheme)
+    {
+        if ($start === 0) {
+            $start = false;
+        }
+        $this->app = $this->generateApplication($charset, $version, $scheme, $start);
+
+        Assertion::keyIsset($this->app, 'sitemap');
+    }
+
+    /**
      * @Given No entry was set
      */
     public function noEntryExists()
@@ -37,6 +50,18 @@ class FeatureContext implements Context, SnippetAcceptingContext
         $sitemap = $this->app['sitemap']->generate(false);
 
         Assertion::eq(0, preg_match('/\<url\>/', $sitemap));
+    }
+
+    /**
+     * @param string $url
+     * @param string $name
+     * @param mixed  $value
+     *
+     * @Given I starting a :element Element
+     */
+    public function startElement($element)
+    {
+        $this->app['sitemap']->startElement($element);
     }
 
     /**
@@ -105,7 +130,7 @@ class FeatureContext implements Context, SnippetAcceptingContext
      * @param string $version
      * @param string $scheme
      */
-    private function generateApplication($charset, $version, $scheme)
+    private function generateApplication($charset, $version, $scheme, $start = true)
     {
         $options = [
             'debug' => true,
@@ -113,6 +138,7 @@ class FeatureContext implements Context, SnippetAcceptingContext
                 'charset' => $charset,
                 'version' => $version,
                 'scheme' => $scheme,
+                'start' => $start,
             ]
         ];
 

--- a/features/provider.feature
+++ b/features/provider.feature
@@ -78,3 +78,17 @@ Feature: Service works expected
       </url>
     </urlset>
     """
+
+  Scenario:
+    Given Service with charset "ISO-8859-1", version "1.1" and scheme "http://www.sitemaps.org/schemas/sitemap/0.8" is available
+    When I add a sitemap "https://github.com/tommy-muehle/silex-sitemap-service-provider" with parameter "lastmod" and value "2016-05-30"
+    Then It should pass with:
+    """
+    <?xml version="1.1" encoding="ISO-8859-1"?>
+    <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.8">
+      <sitemap>
+        <loc>https://github.com/tommy-muehle/silex-sitemap-service-provider</loc>
+        <lastmod>2016-05-30</lastmod>
+      </sitemap>
+    </sitemapindex>
+    """

--- a/features/provider.feature
+++ b/features/provider.feature
@@ -80,11 +80,12 @@ Feature: Service works expected
     """
 
   Scenario:
-    Given Service with charset "ISO-8859-1", version "1.1" and scheme "http://www.sitemaps.org/schemas/sitemap/0.8" is available
+    Given Service with charset "UTF-8", version "1.1", start "0" and scheme "http://www.sitemaps.org/schemas/sitemap/0.8" is available
+    Given I starting a sitemapindex Element
     When I add a sitemap "https://github.com/tommy-muehle/silex-sitemap-service-provider" with parameter "lastmod" and value "2016-05-30"
     Then It should pass with:
     """
-    <?xml version="1.1" encoding="ISO-8859-1"?>
+    <?xml version="1.1" encoding="UTF-8"?>
     <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.8">
       <sitemap>
         <loc>https://github.com/tommy-muehle/silex-sitemap-service-provider</loc>

--- a/src/Provider/SitemapServiceProvider.php
+++ b/src/Provider/SitemapServiceProvider.php
@@ -18,6 +18,7 @@ class SitemapServiceProvider implements ServiceProviderInterface
             'version' => '1.0',
             'charset' => 'utf-8',
             'scheme' => 'http://www.sitemaps.org/schemas/sitemap/0.9',
+            'start' => true
         ];
 
         if (isset($app['sitemap.options']) && is_array($app['sitemap.options'])) {
@@ -26,7 +27,7 @@ class SitemapServiceProvider implements ServiceProviderInterface
 
         $app['sitemap'] = function () use ($options) {
             return new SitemapGenerator(
-                $options['xml_writer'], $options['version'], $options['charset'], $options['scheme']
+                $options['xml_writer'], $options['version'], $options['charset'], $options['scheme'], $options['start']
             );
         };
     }

--- a/src/Service/SitemapGenerator.php
+++ b/src/Service/SitemapGenerator.php
@@ -15,7 +15,7 @@ class SitemapGenerator
      * @param string     $charset
      * @param string     $scheme
      */
-    public function __construct(\XMLWriter $xmlWriter, $version = '1.0', $charset = 'utf-8', $scheme = 'http://www.sitemaps.org/schemas/sitemap/0.9')
+    public function __construct(\XMLWriter $xmlWriter, $version = '1.0', $charset = 'utf-8', $scheme = 'http://www.sitemaps.org/schemas/sitemap/0.9', $start = true)
     {
         $this->sitemap = $xmlWriter;
         $this->sitemap->openMemory();
@@ -23,8 +23,29 @@ class SitemapGenerator
         $this->sitemap->startDocument($version, $charset);
         $this->sitemap->setIndent(true);
 
-        $this->sitemap->startElement('urlset');
+        if ($start) {
+            $this->sitemap->startElement('urlset');
+        }
         $this->sitemap->writeAttribute('xmlns', $scheme);
+    }
+
+    /**
+     * @param string     $type
+     * @return SitemapGenerator
+     */
+    public function startElement($type = 'urlset')
+    {
+        switch ($type) {
+            case 'sitemapindex':
+                $this->sitemap->startElement('sitemapindex');
+                break;
+            case 'urlset':
+            default:
+                $this->sitemap->startElement('urlset');
+                break;
+        }
+
+        return $this;
     }
 
     /**
@@ -32,6 +53,7 @@ class SitemapGenerator
      * @param float     $priority
      * @param string    $changefreq
      * @param \DateTime $lastmod
+     * @return SitemapGenerator
      */
     public function addEntry($url, $priority = 1.0, $changefreq = 'yearly', \DateTime $lastmod = null)
     {
@@ -46,6 +68,28 @@ class SitemapGenerator
         }
 
         $this->sitemap->endElement();
+
+        return $this;
+    }
+
+    /**
+     * @param string    $url
+     * @param \DateTime $lastmod
+     * @return SitemapGenerator
+     */
+    public function addSitemap($url, \DateTime $lastmod = null)
+    {
+        $this->sitemap->startElement('sitemap');
+
+        $this->sitemap->writeElement('loc', $url);
+
+        if ($lastmod instanceof \DateTime) {
+            $this->sitemap->writeElement('lastmod', $lastmod->format('Y-m-d'));
+        }
+
+        $this->sitemap->endElement();
+
+        return $this;
     }
 
     /**

--- a/src/Service/SitemapGenerator.php
+++ b/src/Service/SitemapGenerator.php
@@ -10,6 +10,11 @@ class SitemapGenerator
     protected $sitemap;
 
     /**
+     * @var string scheme
+     */
+    protected $scheme;
+
+    /**
      * @param \XMLWriter $xmlWriter
      * @param string     $version
      * @param string     $charset
@@ -25,8 +30,9 @@ class SitemapGenerator
 
         if ($start) {
             $this->sitemap->startElement('urlset');
+            $this->sitemap->writeAttribute('xmlns', $scheme);
         }
-        $this->sitemap->writeAttribute('xmlns', $scheme);
+        $this->scheme = $scheme;
     }
 
     /**
@@ -44,6 +50,7 @@ class SitemapGenerator
                 $this->sitemap->startElement('urlset');
                 break;
         }
+        $this->sitemap->writeAttribute('xmlns', $this->scheme);
 
         return $this;
     }


### PR DESCRIPTION
This Pull Request add the feature for sitemapindex.

The ReadMe has been modified to explain the new feature.

The start option has been added. It starts automatically the element
urlset. When set to false, it disable the startElement and needs a
manual declaration with the method startElement.
This method has been added to the SitemapGenerator.

The methods addEntry and addSitemap now returns the Class to have the
posibility to chain the entries together. (See the example into the
readme.)

A test has been added to the feature. I am not really familiar yet with Behat.
As PHPunit and PHPspecs are not implemented, I did not add those tests.